### PR TITLE
Ajuste no ponto de criação do escopo

### DIFF
--- a/ASPNET-Worker/ExemploWorker/Workers/TimerWorker.cs
+++ b/ASPNET-Worker/ExemploWorker/Workers/TimerWorker.cs
@@ -6,13 +6,12 @@ namespace ExemploWorker.Workers
     {
         private readonly ILogger<TimerWorker> _logger;
         private Timer? _timer;
-        private readonly ISendEmail _sendEmail; // enviar email
+        private readonly IServiceProvider _serviceProvider;
 
         public TimerWorker(ILogger<TimerWorker> logger, IServiceProvider service)
         {
             _logger = logger;
-            var scope = service.CreateScope().ServiceProvider; // criar escopo para injeção de dependência
-            _sendEmail = scope.GetRequiredService<ISendEmail>(); // enviar email
+            _serviceProvider = service;
         }
         public Task StartAsync(CancellationToken cancellationToken)
         {
@@ -23,7 +22,10 @@ namespace ExemploWorker.Workers
         private void DoWork(object? state)
         {
             _logger.LogInformation("Tempo contando: {time}", DateTimeOffset.Now);
-            _sendEmail.Enviar(); // enviar email
+
+            using var scope = _serviceProvider.CreateScope(); // criar escopo para injeção de dependência
+            var sendEmail = scope.ServiceProvider.GetRequiredService<ISendEmail>();  
+            sendEmail.Enviar(); // enviar email
         }
         public Task StopAsync(CancellationToken cancellationToken)
         {


### PR DESCRIPTION
Esse ajuste visa corrigir o momento de criação do escopo de serviços.

Como `ISendEmail` é um scoped, criar o escopo e resgatar o serviço dentro do construtor do `TimerWorker`, impedirá que `ISendEmail` seja renovado a cada execução, fazendo com que ele se comporte como um Singleton também.

--
Abri este PR, pois não consegui incluir comentários no artigo.

Excelente post Carlos! Obrigado pela contribuição com a comunidade.
Estou sempre seguindo suas publicações.